### PR TITLE
Cleaned up the CI a little.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,6 @@ jobs:
       - name: Install LLVM+Clang
         if: startsWith(matrix.config.name, 'Ubuntu Clang')
         run: |
-          set -x
           cat /etc/lsb-release
           # Remove existing Clang installations.
           sudo apt-get remove \
@@ -70,7 +69,6 @@ jobs:
       - name: Install GCC
         if: startsWith(matrix.config.name, 'Ubuntu GCC')
         run: |
-          set -x
           # Remove existing GCC installations.
           sudo apt-get remove gcc-13 g++-13 gcc-14 g++-14 gcc g++
           sudo apt update
@@ -82,18 +80,14 @@ jobs:
           g++-${GCC_VERSION} --version
       - name: CMake Configure
         run: |
-          set -x
           echo ${{ matrix.config.cmake_args }}
           echo ${{ matrix.config.toolchain }}
-          rm -rf .build
           cmake ${{ matrix.config.cmake_args }} -DCMAKE_TOOLCHAIN_FILE="etc/${{ matrix.config.toolchain }}-toolchain.cmake" -B .build -S .
       - name: CMake Build
         run: |
-          set -x
           cmake --build .build --config Asan --target all -- -k 0
       - name: CMake Test
         run: |
-          set -x
           [[ ! -z "${{ matrix.config.asan_options }}" ]]  && export ASAN_OPTIONS="${{ matrix.config.asan_options }}"
           ctest --build-config Asan --output-on-failure --test-dir .build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,9 @@ jobs:
           - {name: "Ubuntu GCC 12", os: ubuntu-24.04, toolchain: "gcc-12",  cmake_args: "-G \"Ninja Multi-Config\" -DCMAKE_CONFIGURATION_TYPES=\"RelWithDebInfo;Asan\" "}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: 'true'
-      - uses: seanmiddleditch/gha-setup-ninja@master
       - name: Activate verbose shell
         run: set -x
       - name: Install LLVM+Clang

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ name: CI Tests
 on:
   workflow_dispatch:
   push:
-    branches: [main]
+    branches: [main, ci]
   pull_request:
     branches: [main]
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,6 @@ jobs:
       - name: Install LLVM+Clang
         if: startsWith(matrix.config.name, 'Ubuntu Clang')
         run: |
-          cat /etc/lsb-release
           # Remove existing Clang installations.
           sudo apt-get remove \
             clang-${{matrix.config.installed_clang_version}} \


### PR DESCRIPTION
When the PR gets a +1 from the reviewers, I will need to rebase this PR to remove the first command (29018dea0226cc36dc6ee00dfc6734795a3f6eb3) so that it can be merged to `main`. I needed to add the branch to the CI to ensure that my changes weren't breaking anything.

In this PR, I
- removed the unnecessary "Install Ninja" step. If we look at the [specs for the GitHub-hosted `Ubuntu 24.04` runner](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md), we can see that Ninja comes preinstalled. (For further information, this change seems to have been made [near the beginning of the year](https://github.com/actions/runner-images/issues/11391).)
- Removed the spurious `rm -rf .build` step. The runners only come with the default directories. If we didn't make the `.build` directory in a previous step, then it cannot exist.
- Removed the multiple calls to `set -x`. Running that once is enough. The shell persists across the different steps.
- Removed the call to `cat /etc/lsb_release`. It is fine to use that during the development of the CI, but there is no reason to run it every CI run. It just adds to the logs for no reason. We specifically asked for the `Ubuntu 24.04` runner, so all the information we might need to know can be found [here](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md).


Apart from these, I want to also remove the "Install LLVM + Clang" and "Install GCC" steps. Not only would it make the CI script simpler (and therefore reduce the maintenance burden a bit), but also because the current method of doing things makes no sense to me. The `Ubuntu 24.04` runner comes with Clang 16-18 and GCC 12-14 preinstalled. So, I don't quite see the value of removing it and then readding it.

For Clang, we can remove the current script and use the `Install LLVM and Clang`, which would greatly simplify the script, reduce maintenance burden, and remove the need to reinvent the wheel.

For GCC, as far as I can tell, there is no reason for the `Install GCC` step to exist. All the 3 GCC versions we test against are preinstalled in the runner.


I'd be happy to make these changes, but I wanted to get some feedback from the maintainers/community first.